### PR TITLE
Fix error in listing 5.10.

### DIFF
--- a/TFv2/ch05/Listing 5.08 - 5.11.ipynb
+++ b/TFv2/ch05/Listing 5.08 - 5.11.ipynb
@@ -321,8 +321,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# X = tf.constant(tf.zeros([num_labels, num_features]))\n",
-    "# Y = tf.constant(tf.zeros([num_labels, num_labels]))\n",
+    "# X = tf.constant(tf.zeros([batch_size, num_features]))\n",
+    "# Y = tf.constant(tf.zeros([batch_size, num_labels]))\n",
     "X = tf.Variable([0])\n",
     "Y = tf.Variable([0])\n",
     " \n",
@@ -3459,7 +3459,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3473,7 +3473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Though the lines are commented out, the first dimensions of X and Y should be one of batch_size or train_size.